### PR TITLE
readme: badge and logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+<p align="center">
+  <a href="https://sentry.io/?utm_source=github&utm_medium=logo" target="_blank">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-wordmark-dark-280x84.png" alt="Sentry" width="280" height="84">
+  </a>
+</p>
+
+[![npm version](https://img.shields.io/npm/v/@sentry-internal/overhead.svg)](https://www.npmjs.com/package/@sentry-internal/overhead)
+[![Discord](https://img.shields.io/discord/621778831602221064)](https://discord.gg/Ww9hbqr)
+
 # Overhead performance metrics
 
 Evaluates Sentry & Replay impact on website performance by running a web app in Chromium via Playwright and collecting various metrics.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   </a>
 </p>
 
-[![npm version](https://img.shields.io/npm/v/@sentry-internal/overhead.svg)](https://www.npmjs.com/package/@sentry-internal/overhead)
+[![npm version](https://img.shields.io/npm/v/@sentry-internal/web-benchmark.svg)](https://www.npmjs.com/package/@sentry-internal/web-benchmark)
 [![Discord](https://img.shields.io/discord/621778831602221064)](https://discord.gg/Ww9hbqr)
 
 # Overhead performance metrics


### PR DESCRIPTION
`@sentry-internal/overhead` not on npm yet?