### PR TITLE
feat: Add parameters to the command line: device

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ To run:
 | --runs / -c | false    | 1       | The number of times to run the scenario |
 | --cpu       | false    | 1       | The CPU throttle factor. e.g. "2" represents a 2x throttle |
 | --network   | false    | false   | The network speed to emulate (e.g. "Fast 3G" or "Slow 3G") |
+| --device / -d   | false    | false   | The network speed to emulate (e.g. "Iphone 13" or "Desktop Chrome") |
 
 
 ## Resources

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -27,10 +27,14 @@ async function main() {
       short: 'f',
       multiple: true,
     },
+    'device':{
+      type: 'string',
+      short: 'd',
+    }
   }
 
   const {
-    values: { headless, runs, cpu, network, file },
+    values: { headless, runs, cpu, network, file, device },
   } = parseArgs({options});
 
   if (!file || file.length < 1) {
@@ -46,6 +50,7 @@ async function main() {
     headless: headless ?? false,
     cpuThrottling: cpu ? parseFloat(cpu) : false,
     networkConditions: network,
+    device: device,
   });
 
   const result = await collector.execute({


### PR DESCRIPTION
When I wanted to use the mobile terminal for testing, I found that there was no entrance to pass parameters, so I added a command line parameter to facilitate debugging. I hope that it‘’s useful.